### PR TITLE
Refactor with cargo-clippy and cargo-fmt

### DIFF
--- a/benches/bench_window_size.rs
+++ b/benches/bench_window_size.rs
@@ -1,8 +1,5 @@
 use ark_bls12_381::G1Affine;
-use ark_msm::{
-    utils::generate_msm_inputs,
-    msm::VariableBaseMSM
-};
+use ark_msm::{msm::VariableBaseMSM, utils::generate_msm_inputs};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn bench_window_size(c: &mut Criterion) {
@@ -15,7 +12,8 @@ fn bench_window_size(c: &mut Criterion) {
 
         for window_size in (size - 3)..(size + 3) {
             let input = (size, window_size);
-            let benchmark_id = BenchmarkId::new("ArkMSM", format!("k={}, ws={}", size, window_size));
+            let benchmark_id =
+                BenchmarkId::new("ArkMSM", format!("k={}, ws={}", size, window_size));
             group.bench_with_input(benchmark_id, &input, |b, _input| {
                 b.iter(|| {
                     let _ = VariableBaseMSM::multi_scalar_mul_custom(
@@ -23,14 +21,14 @@ fn bench_window_size(c: &mut Criterion) {
                         &scalar_vec,
                         window_size,
                         2048,
-                        256);
+                        256,
+                    );
                 })
             });
         }
     }
     group.finish();
 }
-
 
 criterion_group!(benches, bench_window_size);
 criterion_main!(benches);

--- a/benches/bench_with_baseline.rs
+++ b/benches/bench_with_baseline.rs
@@ -1,11 +1,7 @@
-use criterion::{BenchmarkId, black_box, Criterion, criterion_group, criterion_main};
 use ark_bls12_381::G1Affine;
-use ark_msm::{
-    utils::generate_msm_inputs,
-    msm::VariableBaseMSM
-};
 use ark_ec::msm::VariableBaseMSM as BaselineVariableBaseMSM;
-
+use ark_msm::{msm::VariableBaseMSM, utils::generate_msm_inputs};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn benchmark_with_baseline(c: &mut Criterion) {
     let mut group = c.benchmark_group("msm");

--- a/src/batch_adder.rs
+++ b/src/batch_adder.rs
@@ -1,9 +1,6 @@
+use ark_ec::{models::SWModelParameters as Parameters, short_weierstrass_jacobian::GroupAffine};
 use ark_ff::Field;
 use ark_std::{One, Zero};
-use ark_ec::{
-    short_weierstrass_jacobian::GroupAffine,
-    models::SWModelParameters as Parameters
-};
 
 pub struct BatchAdder<P: Parameters> {
     inverse_state: P::BaseField,
@@ -20,7 +17,10 @@ impl<P: Parameters> BatchAdder<P> {
 
     /// Batch add vector dest and src, the results will be stored in dest, i.e. dest[i] = dest[i] + src[i]
     pub fn batch_add(&mut self, dest: &mut [GroupAffine<P>], src: &[GroupAffine<P>]) {
-        assert!(dest.len() == src.len(), "length of dest and src don't match!");
+        assert!(
+            dest.len() == src.len(),
+            "length of dest and src don't match!"
+        );
         assert!(dest.len() <= self.inverses.len(),
                 "input length exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!");
 
@@ -36,14 +36,22 @@ impl<P: Parameters> BatchAdder<P> {
 
     /// Batch add vector dest and src of len entries, skipping dest_step and src_step entries each
     /// the results will be stored in dest, i.e. dest[i] = dest[i] + src[i]
-    pub fn batch_add_step_n(&mut self,
-                            dest: &mut [GroupAffine<P>],
-                            dest_step: usize,
-                            src: &[GroupAffine<P>],
-                            src_step: usize,
-                            len: usize) {
-        assert!(dest.len() > (len - 1) * dest_step, "insufficient entries in dest array");
-        assert!(src.len() > (len - 1) * src_step, "insufficient entries in src array");
+    pub fn batch_add_step_n(
+        &mut self,
+        dest: &mut [GroupAffine<P>],
+        dest_step: usize,
+        src: &[GroupAffine<P>],
+        src_step: usize,
+        len: usize,
+    ) {
+        assert!(
+            dest.len() > (len - 1) * dest_step,
+            "insufficient entries in dest array"
+        );
+        assert!(
+            src.len() > (len - 1) * src_step,
+            "insufficient entries in src array"
+        );
         assert!(len <= self.inverses.len(),
                 "input length exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!");
 
@@ -59,23 +67,40 @@ impl<P: Parameters> BatchAdder<P> {
 
     /// Batch add vector dest[dest_index] and src[src_index] using the specified indexes in input
     /// the results will be stored in dest, i.e. dest[i] = dest[i] + src[i]
-    pub fn batch_add_indexed(&mut self,
-                            dest: &mut [GroupAffine<P>],
-                            dest_indexes: &[u32],
-                            src: &[GroupAffine<P>],
-                            src_indexes: &[u32]) {
-        assert!(dest.len() >= dest_indexes.len(), "insufficient entries in dest array");
+    pub fn batch_add_indexed(
+        &mut self,
+        dest: &mut [GroupAffine<P>],
+        dest_indexes: &[u32],
+        src: &[GroupAffine<P>],
+        src_indexes: &[u32],
+    ) {
+        assert!(
+            dest.len() >= dest_indexes.len(),
+            "insufficient entries in dest array"
+        );
         assert!(dest_indexes.len() <= self.inverses.len(),
                 "input length exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!");
-        assert_eq!(dest_indexes.len(), src_indexes.len(), "length of dest_indexes and src_indexes don't match!");
+        assert_eq!(
+            dest_indexes.len(),
+            src_indexes.len(),
+            "length of dest_indexes and src_indexes don't match!"
+        );
 
         self.reset();
         for i in 0..dest_indexes.len() {
-            self.batch_add_phase_one(&dest[dest_indexes[i] as usize], &src[src_indexes[i] as usize], i);
+            self.batch_add_phase_one(
+                &dest[dest_indexes[i] as usize],
+                &src[src_indexes[i] as usize],
+                i,
+            );
         }
         self.inverse();
         for i in (0..dest_indexes.len()).rev() {
-            self.batch_add_phase_two(&mut dest[dest_indexes[i] as usize], &src[src_indexes[i] as usize], i);
+            self.batch_add_phase_two(
+                &mut dest[dest_indexes[i] as usize],
+                &src[src_indexes[i] as usize],
+                i,
+            );
         }
     }
 
@@ -96,14 +121,11 @@ impl<P: Parameters> BatchAdder<P> {
     ///      - slope s and ss from state
     ///      - inverse_state = inverse_state * deltaX
     ///      - addition result acc
-    pub fn batch_add_phase_one(
-            &mut self,
-            p: &GroupAffine<P>,
-            q: &GroupAffine<P>,
-            idx: usize,
-        ) {
-        assert!(idx < self.inverses.len(),
-                "index exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!");
+    pub fn batch_add_phase_one(&mut self, p: &GroupAffine<P>, q: &GroupAffine<P>, idx: usize) {
+        assert!(
+            idx < self.inverses.len(),
+            "index exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!"
+        );
         if p.is_zero() | q.is_zero() {
             return;
         }
@@ -131,17 +153,14 @@ impl<P: Parameters> BatchAdder<P> {
     }
 
     /// should call inverse() between phase_one and phase_two
-    pub fn batch_add_phase_two(
-            &mut self,
-            p: &mut GroupAffine<P>,
-            q: &GroupAffine<P>,
-            idx: usize,
-        ) {
-        assert!(idx < self.inverses.len(),
-                "index exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!");
+    pub fn batch_add_phase_two(&mut self, p: &mut GroupAffine<P>, q: &GroupAffine<P>, idx: usize) {
+        assert!(
+            idx < self.inverses.len(),
+            "index exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!"
+        );
         if p.is_zero() | q.is_zero() {
             if !q.is_zero() {
-                *p = q.clone();
+                *p = *q;
             }
             return;
         }
@@ -176,7 +195,7 @@ impl<P: Parameters> BatchAdder<P> {
         p.x = ss - q.x - p.x;
         delta_x = q.x - p.x;
         p.y = s * delta_x;
-        p.y = p.y - q.y;
+        p.y -= q.y;
     }
 }
 
@@ -184,30 +203,22 @@ impl<P: Parameters> BatchAdder<P> {
 mod batch_add_tests {
     use super::*;
     use ark_bls12_381::G1Affine;
-    use ark_ec::{ProjectiveCurve, AffineCurve};
+    use ark_ec::{AffineCurve, ProjectiveCurve};
     use ark_std::UniformRand;
     use std::ops::Add;
 
     #[test]
     fn test_phase_one_zero_or_neg() {
         let mut batch_adder = BatchAdder::new(4);
-        batch_adder.batch_add_phase_one(
-            &G1Affine::zero(),
-            &G1Affine::zero(),
-            0
-        );
+        batch_adder.batch_add_phase_one(&G1Affine::zero(), &G1Affine::zero(), 0);
 
         let mut rng = ark_std::test_rng();
         let p = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let p_affine = G1Affine::from(p);
-        let mut neg_p_affine = p_affine.clone();
+        let mut neg_p_affine = p_affine;
         neg_p_affine.y = -neg_p_affine.y;
 
-        batch_adder.batch_add_phase_one(
-            &p_affine,
-            &neg_p_affine,
-            0
-        );
+        batch_adder.batch_add_phase_one(&p_affine, &neg_p_affine, 0);
     }
 
     #[test]
@@ -216,10 +227,10 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let p = G1Affine::from(prj);
-        let acc = p.clone();
+        let acc = p;
 
         batch_adder.batch_add_phase_one(&acc, &p, 0);
-        assert_eq!(batch_adder.inverses[0].is_one(), true);
+        assert!(batch_adder.inverses[0].is_one());
         assert_eq!(batch_adder.inverse_state, p.y + p.y);
     }
 
@@ -233,7 +244,7 @@ mod batch_add_tests {
         let q = G1Affine::from(q_prj);
 
         batch_adder.batch_add_phase_one(&p, &q, 0);
-        assert_eq!(batch_adder.inverses[0].is_one(), true);
+        assert!(batch_adder.inverses[0].is_one());
         assert_eq!(batch_adder.inverse_state, q.x - p.x);
     }
 
@@ -270,7 +281,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let p_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(p_prj);
-        let mut p = acc.clone();
+        let mut p = acc;
         p.y = -p.y;
 
         batch_adder.batch_add_phase_two(&mut acc, &p, 0);
@@ -284,7 +295,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let acc_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(acc_prj);
-        let mut p = acc.clone();
+        let mut p = acc;
         p.x = p.x + p.x;
 
         batch_adder.inverses[0] = (p.x - acc.x).inverse().unwrap();
@@ -299,7 +310,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let acc_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(acc_prj);
-        let p = acc.clone();
+        let p = acc;
 
         batch_adder.inverses[0] = (p.y + p.y).inverse().unwrap();
         batch_adder.batch_add_phase_two(&mut acc, &p, 0);
@@ -371,8 +382,12 @@ mod batch_add_tests {
         let mut batch_adder = BatchAdder::new(1);
         let mut rng = ark_std::test_rng();
 
-        let mut buckets: Vec<G1Affine> = vec![G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng))];
-        let points: Vec<G1Affine> = vec![G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng))];
+        let mut buckets: Vec<G1Affine> = vec![G1Affine::from(
+            <G1Affine as AffineCurve>::Projective::rand(&mut rng),
+        )];
+        let points: Vec<G1Affine> = vec![G1Affine::from(
+            <G1Affine as AffineCurve>::Projective::rand(&mut rng),
+        )];
 
         let tmp = buckets.clone();
         batch_adder.batch_add_indexed(&mut buckets, &[0], &points, &[0]);

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -17,7 +17,7 @@ impl Bitmap {
             return true;
         }
         self.data[word as usize] |= bit;
-        return false;
+        false
     }
 
     pub fn clear(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
-pub mod utils;
+#![allow(clippy::needless_range_loop)]
+
 pub mod bitmap;
 pub mod glv;
-pub mod types;
 pub mod msm;
+pub mod types;
+pub mod utils;
 
-mod bucket_msm;
 mod batch_adder;
+mod bucket_msm;

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -1,16 +1,16 @@
-use std::any::TypeId;
 use crate::{
     bucket_msm::BucketMSM,
-    glv::{decompose},
-    types::{G1BigInt, BigInt, G1_SCALAR_SIZE_GLV, GROUP_SIZE_IN_BITS},
+    glv::decompose,
+    types::{BigInt, G1BigInt, G1_SCALAR_SIZE_GLV, GROUP_SIZE_IN_BITS},
 };
-use ark_bls12_381::{Fr, g1::Parameters as G1Parameters};
+use ark_bls12_381::{g1::Parameters as G1Parameters, Fr};
+use ark_ec::{
+    models::SWModelParameters as Parameters,
+    short_weierstrass_jacobian::{GroupAffine, GroupProjective},
+};
 use ark_ff::{BigInteger, PrimeField};
 use ark_std::log2;
-use ark_ec::{
-    short_weierstrass_jacobian::{GroupAffine, GroupProjective},
-    models::SWModelParameters as Parameters
-};
+use std::any::TypeId;
 
 pub struct VariableBaseMSM;
 
@@ -37,28 +37,28 @@ impl VariableBaseMSM {
             20 => 15,
             21 => 15,
             22 => 15,
-            _ => 16
+            _ => 16,
         }
     }
 
-    fn msm_slice<P: Parameters>(scalar: BigInt<P>, slices: &mut Vec<u32>, window_bits: u32) {
+    fn msm_slice<P: Parameters>(scalar: BigInt<P>, slices: &mut [u32], window_bits: u32) {
         assert!(window_bits <= 31); // reserve one bit for marking signed slices
         let mut temp = scalar;
-        for i in 0..slices.len() {
-            slices[i] = (temp.as_ref()[0] % (1 << window_bits)) as u32;
+        for el in slices.iter_mut() {
+            *el = (temp.as_ref()[0] % (1 << window_bits)) as u32;
             temp.divn(window_bits);
         }
 
         let mut carry = 0;
         let total = 1 << window_bits;
         let half = total >> 1;
-        for i in 0..slices.len() {
-            slices[i] += carry;
-            if slices[i] > half {
+        for el in slices.iter_mut() {
+            *el += carry;
+            if half < *el {
                 // slices[i] == half is okay, since (slice[i]-1) will be used for bucket_id
-                slices[i] = total - slices[i];
+                *el = total - *el;
                 carry = 1;
-                slices[i] |= 1 << 31; // mark the highest bit for later
+                *el |= 1 << 31; // mark the highest bit for later
             } else {
                 carry = 0;
             }
@@ -74,34 +74,34 @@ impl VariableBaseMSM {
         scalars: &[BigInt<P>],
         window_bits: u32,
         max_batch: u32,
-        max_collisions: u32
+        max_collisions: u32,
     ) -> GroupProjective<P> {
         let num_slices: u32 = (G1_SCALAR_SIZE_GLV + window_bits - 1) / window_bits;
-        let mut bucket_msm = BucketMSM::<P>::new(
-            G1_SCALAR_SIZE_GLV,
-            window_bits,
-            max_batch,
-            max_collisions,
-        );
+        let mut bucket_msm =
+            BucketMSM::<P>::new(G1_SCALAR_SIZE_GLV, window_bits, max_batch, max_collisions);
         // scalar = phi * lambda + normal
         let mut phi_slices: Vec<u32> = vec![0; num_slices as usize];
         let mut normal_slices: Vec<u32> = vec![0; num_slices as usize];
 
-        let scalars_and_bases_iter = scalars
-            .iter()
-            .zip(points)
-            .filter(|(s, _)| !s.is_zero());
+        let scalars_and_bases_iter = scalars.iter().zip(points).filter(|(s, _)| !s.is_zero());
         scalars_and_bases_iter.for_each(|(&scalar, point)| {
             // use unsafe cast for type conversion until we have a better approach
-            let g1_scalar: G1BigInt= unsafe { *(std::ptr::addr_of!(scalar) as *const G1BigInt) };
-            let (phi, normal, is_neg_scalar, is_neg_normal) = decompose(&Fr::from(g1_scalar), window_bits);
+            let g1_scalar: G1BigInt = unsafe { *(std::ptr::addr_of!(scalar) as *const G1BigInt) };
+            let (phi, normal, is_neg_scalar, is_neg_normal) =
+                decompose(&Fr::from(g1_scalar), window_bits);
             Self::msm_slice::<G1Parameters>(phi.into(), &mut phi_slices, window_bits);
             Self::msm_slice::<G1Parameters>(normal.into(), &mut normal_slices, window_bits);
-            bucket_msm.process_point_and_slices_glv(&point, &normal_slices, &phi_slices, is_neg_scalar, is_neg_normal);
+            bucket_msm.process_point_and_slices_glv(
+                point,
+                &normal_slices,
+                &phi_slices,
+                is_neg_scalar,
+                is_neg_normal,
+            );
         });
 
         bucket_msm.process_complete();
-        return bucket_msm.batch_reduce();
+        bucket_msm.batch_reduce()
     }
 
     fn multi_scalar_mul_general<P: Parameters>(
@@ -109,29 +109,22 @@ impl VariableBaseMSM {
         scalars: &[BigInt<P>],
         window_bits: u32,
         max_batch: u32,
-        max_collisions: u32
+        max_collisions: u32,
     ) -> GroupProjective<P> {
         let scalar_size = <P::ScalarField as PrimeField>::size_in_bits() as u32;
         let num_slices: u32 = (scalar_size + window_bits - 1) / window_bits;
-        let mut bucket_msm = BucketMSM::<P>::new(
-            scalar_size,
-            window_bits,
-            max_batch,
-            max_collisions,
-        );
+        let mut bucket_msm =
+            BucketMSM::<P>::new(scalar_size, window_bits, max_batch, max_collisions);
         let mut slices: Vec<u32> = vec![0; num_slices as usize];
 
-        let scalars_and_bases_iter = scalars
-            .iter()
-            .zip(points)
-            .filter(|(s, _)| !s.is_zero());
+        let scalars_and_bases_iter = scalars.iter().zip(points).filter(|(s, _)| !s.is_zero());
         scalars_and_bases_iter.for_each(|(&scalar, point)| {
             Self::msm_slice::<P>(scalar, &mut slices, window_bits);
-            bucket_msm.process_point_and_slices(&point, &slices);
+            bucket_msm.process_point_and_slices(point, &slices);
         });
 
         bucket_msm.process_complete();
-        return bucket_msm.batch_reduce();
+        bucket_msm.batch_reduce()
     }
 
     pub fn multi_scalar_mul_custom<P: Parameters>(
@@ -139,10 +132,12 @@ impl VariableBaseMSM {
         scalars: &[BigInt<P>],
         window_bits: u32,
         max_batch: u32,
-        max_collisions: u32
+        max_collisions: u32,
     ) -> GroupProjective<P> {
-        assert!(window_bits as usize > GROUP_SIZE_IN_BITS,
-                "Window_bits must be greater than the default log(group size)");
+        assert!(
+            window_bits as usize > GROUP_SIZE_IN_BITS,
+            "Window_bits must be greater than the default log(group size)"
+        );
         if TypeId::of::<P>() == TypeId::of::<G1Parameters>() {
             Self::multi_scalar_mul_g1_glv(points, scalars, window_bits, max_batch, max_collisions)
         } else {
@@ -150,12 +145,14 @@ impl VariableBaseMSM {
         }
     }
 
-    pub fn multi_scalar_mul<P: Parameters>(points: &[GroupAffine<P>], scalars: &[BigInt<P>]) -> GroupProjective<P> {
+    pub fn multi_scalar_mul<P: Parameters>(
+        points: &[GroupAffine<P>],
+        scalars: &[BigInt<P>],
+    ) -> GroupProjective<P> {
         let opt_window_size = Self::get_opt_window_size(log2(points.len()));
-        Self::multi_scalar_mul_custom(&points, &scalars, opt_window_size, 2048, 256)
+        Self::multi_scalar_mul_custom(points, scalars, opt_window_size, 2048, 256)
     }
 }
-
 
 #[cfg(test)]
 mod collision_method_pippenger_tests {
@@ -168,14 +165,14 @@ mod collision_method_pippenger_tests {
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 1);
         // print!("slices {:?}\n", slices);
-        assert_eq!(slices.iter().eq([1, 0, 1].iter()), true);
+        assert!(slices.iter().eq([1, 0, 1].iter()));
     }
     #[test]
     fn test_msm_slice_window_size_2() {
         let scalar = G1BigInt::from(0b000110);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 2);
-        assert_eq!(slices.iter().eq([2, 1, 0].iter()), true);
+        assert!(slices.iter().eq([2, 1, 0].iter()));
     }
 
     #[test]
@@ -183,7 +180,7 @@ mod collision_method_pippenger_tests {
         let scalar = G1BigInt::from(0b010111000);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 3);
-        assert_eq!(slices.iter().eq([0, 0x80000001, 3].iter()), true);
+        assert!(slices.iter().eq([0, 0x80000001, 3].iter()));
     }
 
     #[test]
@@ -191,6 +188,6 @@ mod collision_method_pippenger_tests {
         let scalar = G1BigInt::from(0x123400007FFF);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 16);
-        assert_eq!(slices.iter().eq([0x7FFF, 0, 0x1234].iter()), true);
+        assert!(slices.iter().eq([0x7FFF, 0, 0x1234].iter()));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,13 +1,9 @@
 use ark_bls12_381::G1Affine;
-use ark_ec::{
-    AffineCurve,
-    models::ModelParameters
-};
+use ark_ec::{models::ModelParameters, AffineCurve};
 use ark_ff::{FpParameters, PrimeField};
 
 pub const G1_SCALAR_SIZE: u32 =
-    <<<G1Affine as AffineCurve>::ScalarField as PrimeField>::Params as FpParameters>::MODULUS_BITS
-        as u32;
+    <<<G1Affine as AffineCurve>::ScalarField as PrimeField>::Params as FpParameters>::MODULUS_BITS;
 pub const G1_SCALAR_SIZE_GLV: u32 = 128u32;
 pub const GROUP_SIZE_IN_BITS: usize = 6;
 pub const GROUP_SIZE: usize = 1 << GROUP_SIZE_IN_BITS;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{PrimeField, UniformRand};
 
+#[allow(clippy::type_complexity)]
 pub fn generate_msm_inputs<A>(
     size: usize,
 ) -> (

--- a/tests/bitmap_tests.rs
+++ b/tests/bitmap_tests.rs
@@ -3,30 +3,30 @@ mod bitmap_tests {
     use ark_msm::bitmap::Bitmap;
 
     fn setup() -> Bitmap {
-        return Bitmap::new(67);
+        Bitmap::new(67)
     }
 
     #[test]
     fn test_set_when_only_once_return_false() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(33), false);
+        assert!(!bitmap.test_and_set(0));
+        assert!(!bitmap.test_and_set(33));
     }
 
     #[test]
     fn test_set_when_more_than_once_return_true() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(0), true);
+        assert!(!bitmap.test_and_set(0));
+        assert!(bitmap.test_and_set(0));
     }
 
     #[test]
     fn test_clear() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(0), true);
+        assert!(!bitmap.test_and_set(0));
+        assert!(bitmap.test_and_set(0));
 
         bitmap.clear();
-        assert_eq!(bitmap.test_and_set(0), false);
+        assert!(!bitmap.test_and_set(0));
     }
 }

--- a/tests/glv_tests.rs
+++ b/tests/glv_tests.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod glv_tests {
-    use ark_msm::{glv::*, types::G1ScalarField};
-    use ark_bls12_381::{G1Affine, Fr};
+    use ark_bls12_381::{Fr, G1Affine};
     use ark_ec::AffineCurve;
-    use ark_ff::{UniformRand, PrimeField, BigInteger256};
+    use ark_ff::{BigInteger256, PrimeField, UniformRand};
+    use ark_msm::{glv::*, types::G1ScalarField};
     use num_bigint::BigUint;
 
     #[test]
@@ -37,7 +37,11 @@ mod glv_tests {
 
         let lambda: u128 = 0xac45a4010001a40200000000ffffffff;
         let mut ss: BigUint = s.into();
-        let modulus: BigUint = BigUint::parse_bytes(b"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001", 16).unwrap();
+        let modulus: BigUint = BigUint::parse_bytes(
+            b"73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001",
+            16,
+        )
+        .unwrap();
         if s.into_repr().as_ref()[3] >= 0x3FFFFFFFF {
             ss = modulus - ss;
         }
@@ -58,7 +62,7 @@ mod glv_tests {
         ]));
         let p = G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng));
 
-        let mut endo_p = p.clone();
+        let mut endo_p = p;
         endomorphism(&mut endo_p);
 
         let lambda_p = G1Affine::from(p.mul(lambda));

--- a/tests/msm_tests.rs
+++ b/tests/msm_tests.rs
@@ -1,11 +1,8 @@
 use ark_bls12_381::G1Affine;
+use ark_ec::msm::VariableBaseMSM as BaselineVariableBaseMSM;
 use ark_ec::AffineCurve;
 use ark_ff::PrimeField;
-use ark_msm::{
-    utils::generate_msm_inputs,
-    msm::VariableBaseMSM
-};
-use ark_ec::msm::VariableBaseMSM as BaselineVariableBaseMSM;
+use ark_msm::{msm::VariableBaseMSM, utils::generate_msm_inputs};
 
 #[cfg(test)]
 mod msm_test {
@@ -14,14 +11,8 @@ mod msm_test {
     use ark_std::UniformRand;
 
     fn verify_correctness(points: &[G1Affine], scalars: &[G1BigInt], window_size: u32) {
-        let baseline = BaselineVariableBaseMSM::multi_scalar_mul(&points, &scalars);
-        let opt = VariableBaseMSM::multi_scalar_mul_custom(
-            &points,
-            &scalars,
-            window_size,
-            2048,
-            256
-        );
+        let baseline = BaselineVariableBaseMSM::multi_scalar_mul(points, scalars);
+        let opt = VariableBaseMSM::multi_scalar_mul_custom(points, scalars, window_size, 2048, 256);
         assert_eq!(baseline, opt);
     }
 
@@ -32,7 +23,9 @@ mod msm_test {
         let mut points: Vec<_> = Vec::new();
         let mut scalars: Vec<_> = Vec::new();
         for _ in 0..num_points {
-            points.push(G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng)));
+            points.push(G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(
+                &mut rng,
+            )));
             scalars.push(<G1Affine as AffineCurve>::ScalarField::rand(&mut rng).into_repr());
         }
 
@@ -62,7 +55,9 @@ mod msm_test {
         let mut points: Vec<_> = Vec::new();
         let mut scalars: Vec<_> = Vec::new();
         for _ in 0..num_points {
-            points.push(G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng)));
+            points.push(G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(
+                &mut rng,
+            )));
             scalars.push(<G1Affine as AffineCurve>::ScalarField::rand(&mut rng).into_repr());
         }
 


### PR DESCRIPTION
I've been reviewing your codebase and would like to suggest the adoption of Rust's clippy and fmt tools for this project.

Incorporating clippy could enhance code quality by catching common mistakes and potential bugs early. On the other hand, fmt can help enforce a consistent coding style for improved readability and maintenance. Both tools are highly regarded in the Rust community and would align this project more closely with ecosystem standards. 

I turned off a couple of rules that may not be very intuitive for non-Rust devs (clippy insists on iterating through iterators rather than indexes for example). If you have specific formatting preferences or don't like the suggested changes, I'd welcome any feedback. Almost all of the changes made here are `cargo fmt` + `cargo clippy --fix`.

If you decide that using Rust standards is appropriate for your project, these checks can be included at the github-actions level, which are free for open-source projects.

Thank you for considering this proposal! 
