### PR TITLE
Refactor with cargo-clippy and `all_asserts`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,40 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  unit_tests:
+  ci:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy
+
+    - name: Format
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
+
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --all --verbose
+
+    - name: Clippy
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy
+        args: --all-targets --all-features -- -D warnings
+
+    - name: Tests
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --verbose
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ ark-ec = {version = "0.3.0"}
 ark-ff = {version = "0.3.0"}
 ark-std = {version = "0.3.0"}
 num-bigint = {version = "0.4.0"}
+all_asserts = "2.3.1"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/batch_adder.rs
+++ b/src/batch_adder.rs
@@ -1,3 +1,4 @@
+use all_asserts::assert_lt;
 use ark_ec::{models::SWModelParameters as Parameters, short_weierstrass_jacobian::GroupAffine};
 use ark_ff::Field;
 use ark_std::{One, Zero};
@@ -154,8 +155,9 @@ impl<P: Parameters> BatchAdder<P> {
 
     /// should call inverse() between phase_one and phase_two
     pub fn batch_add_phase_two(&mut self, p: &mut GroupAffine<P>, q: &GroupAffine<P>, idx: usize) {
-        assert!(
-            idx < self.inverses.len(),
+        assert_lt!(
+            idx,
+            self.inverses.len(),
             "index exceeds the max_batch_cnt, please increase max_batch_cnt during initialization!"
         );
         if p.is_zero() | q.is_zero() {

--- a/src/batch_adder.rs
+++ b/src/batch_adder.rs
@@ -160,7 +160,7 @@ impl<P: Parameters> BatchAdder<P> {
         );
         if p.is_zero() | q.is_zero() {
             if !q.is_zero() {
-                *p = q.clone();
+                *p = *q;
             }
             return;
         }
@@ -195,7 +195,7 @@ impl<P: Parameters> BatchAdder<P> {
         p.x = ss - q.x - p.x;
         delta_x = q.x - p.x;
         p.y = s * delta_x;
-        p.y = p.y - q.y;
+        p.y -= q.y;
     }
 }
 
@@ -215,7 +215,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let p = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let p_affine = G1Affine::from(p);
-        let mut neg_p_affine = p_affine.clone();
+        let mut neg_p_affine = p_affine;
         neg_p_affine.y = -neg_p_affine.y;
 
         batch_adder.batch_add_phase_one(&p_affine, &neg_p_affine, 0);
@@ -227,10 +227,10 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let p = G1Affine::from(prj);
-        let acc = p.clone();
+        let acc = p;
 
         batch_adder.batch_add_phase_one(&acc, &p, 0);
-        assert_eq!(batch_adder.inverses[0].is_one(), true);
+        assert!(batch_adder.inverses[0].is_one());
         assert_eq!(batch_adder.inverse_state, p.y + p.y);
     }
 
@@ -244,7 +244,7 @@ mod batch_add_tests {
         let q = G1Affine::from(q_prj);
 
         batch_adder.batch_add_phase_one(&p, &q, 0);
-        assert_eq!(batch_adder.inverses[0].is_one(), true);
+        assert!(batch_adder.inverses[0].is_one());
         assert_eq!(batch_adder.inverse_state, q.x - p.x);
     }
 
@@ -281,7 +281,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let p_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(p_prj);
-        let mut p = acc.clone();
+        let mut p = acc;
         p.y = -p.y;
 
         batch_adder.batch_add_phase_two(&mut acc, &p, 0);
@@ -295,7 +295,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let acc_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(acc_prj);
-        let mut p = acc.clone();
+        let mut p = acc;
         p.x = p.x + p.x;
 
         batch_adder.inverses[0] = (p.x - acc.x).inverse().unwrap();
@@ -310,7 +310,7 @@ mod batch_add_tests {
         let mut rng = ark_std::test_rng();
         let acc_prj = <G1Affine as AffineCurve>::Projective::rand(&mut rng);
         let mut acc = G1Affine::from(acc_prj);
-        let p = acc.clone();
+        let p = acc;
 
         batch_adder.inverses[0] = (p.y + p.y).inverse().unwrap();
         batch_adder.batch_add_phase_two(&mut acc, &p, 0);

--- a/src/bitmap.rs
+++ b/src/bitmap.rs
@@ -17,7 +17,7 @@ impl Bitmap {
             return true;
         }
         self.data[word as usize] |= bit;
-        return false;
+        false
     }
 
     pub fn clear(&mut self) {

--- a/src/glv.rs
+++ b/src/glv.rs
@@ -65,11 +65,11 @@ pub fn decompose(
     // r = scalar - t
     let mut carry: i128 = s0 as i128 - (t0 & MASK64) as i128;
     let mut r0: u64 = (carry as u128 & MASK64) as u64;
-    carry = carry >> 64;
+    carry >>= 64;
 
     carry += s1 as i128 - (t1 & MASK64) as i128;
     let mut r1: u64 = (carry as u128 & MASK64) as u64;
-    carry = carry >> 64;
+    carry >>= 64;
 
     carry += s2 as i128 - (t2 & MASK64) as i128;
     let mut r2: u64 = (carry as u128 & MASK64) as u64;
@@ -81,11 +81,11 @@ pub fn decompose(
     loop {
         carry = r0 as i128 - LMDA0 as i128;
         let t0: u64 = (carry as u128 & MASK64) as u64;
-        carry = carry >> 64;
+        carry >>= 64;
 
         carry += r1 as i128 - LMDA1 as i128;
         let t1: u64 = (carry as u128 & MASK64) as u64;
-        carry = carry >> 64;
+        carry >>= 64;
 
         if carry < 0 && r2 == 0 {
             // went negative
@@ -152,15 +152,15 @@ fn glv_preprocess_scalar(
             let mut carry: i128 = 0;
             carry = carry + R0 - s[0] as i128;
             s[0] = (carry as u128 & MASK64) as u64;
-            carry = carry >> 64;
+            carry >>= 64;
 
             carry = carry + R1 - s[1] as i128;
             s[1] = (carry as u128 & MASK64) as u64;
-            carry = carry >> 64;
+            carry >>= 64;
 
             carry = carry + R2 - s[2] as i128;
             s[2] = (carry as u128 & MASK64) as u64;
-            carry = carry >> 64;
+            carry >>= 64;
 
             carry = carry + R3 - s[3] as i128;
             s[3] = (carry as u128 & MASK64) as u64;
@@ -189,7 +189,7 @@ fn glv_post_processing(q0: &mut u128, q1: &mut u128, r0: &mut u64, r1: &mut u64)
         let mut carry: i128 = 0;
         carry = carry + LMDA0 as i128 - *r0 as i128;
         *r0 = (carry as u128 & MASK64) as u64;
-        carry = carry >> 64;
+        carry >>= 64;
 
         carry = carry + LMDA1 as i128 - *r1 as i128;
         *r1 = (carry as u128 & MASK64) as u64;
@@ -208,5 +208,5 @@ pub fn endomorphism(point: &mut G1Affine) {
         return;
     }
 
-    point.x = point.x * BETA;
+    point.x *= BETA;
 }

--- a/src/glv.rs
+++ b/src/glv.rs
@@ -1,3 +1,4 @@
+use all_asserts::assert_lt;
 use ark_bls12_381::G1Affine;
 use ark_ff::{field_new, BigInteger256, PrimeField};
 use ark_std::Zero;
@@ -75,7 +76,7 @@ pub fn decompose(
     let mut r2: u64 = (carry as u128 & MASK64) as u64;
 
     // remainder is at most 3 * LAMBDA, 130 bit
-    assert!(r2 < 4, "remainder at most 130 bit");
+    assert_lt!(r2, 4, "remainder at most 130 bit");
 
     let mut correction = 0u32;
     loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_range_loop)]
+
 pub mod bitmap;
 pub mod glv;
 pub mod msm;

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -41,24 +41,24 @@ impl VariableBaseMSM {
         }
     }
 
-    fn msm_slice<P: Parameters>(scalar: BigInt<P>, slices: &mut Vec<u32>, window_bits: u32) {
+    fn msm_slice<P: Parameters>(scalar: BigInt<P>, slices: &mut [u32], window_bits: u32) {
         assert!(window_bits <= 31); // reserve one bit for marking signed slices
         let mut temp = scalar;
-        for i in 0..slices.len() {
-            slices[i] = (temp.as_ref()[0] % (1 << window_bits)) as u32;
+        for el in slices.iter_mut() {
+            *el = (temp.as_ref()[0] % (1 << window_bits)) as u32;
             temp.divn(window_bits);
         }
 
         let mut carry = 0;
         let total = 1 << window_bits;
         let half = total >> 1;
-        for i in 0..slices.len() {
-            slices[i] += carry;
-            if slices[i] > half {
+        for el in slices.iter_mut() {
+            *el += carry;
+            if half < *el {
                 // slices[i] == half is okay, since (slice[i]-1) will be used for bucket_id
-                slices[i] = total - slices[i];
+                *el = total - *el;
                 carry = 1;
-                slices[i] |= 1 << 31; // mark the highest bit for later
+                *el |= 1 << 31; // mark the highest bit for later
             } else {
                 carry = 0;
             }
@@ -92,7 +92,7 @@ impl VariableBaseMSM {
             Self::msm_slice::<G1Parameters>(phi.into(), &mut phi_slices, window_bits);
             Self::msm_slice::<G1Parameters>(normal.into(), &mut normal_slices, window_bits);
             bucket_msm.process_point_and_slices_glv(
-                &point,
+                point,
                 &normal_slices,
                 &phi_slices,
                 is_neg_scalar,
@@ -101,7 +101,7 @@ impl VariableBaseMSM {
         });
 
         bucket_msm.process_complete();
-        return bucket_msm.batch_reduce();
+        bucket_msm.batch_reduce()
     }
 
     fn multi_scalar_mul_general<P: Parameters>(
@@ -120,11 +120,11 @@ impl VariableBaseMSM {
         let scalars_and_bases_iter = scalars.iter().zip(points).filter(|(s, _)| !s.is_zero());
         scalars_and_bases_iter.for_each(|(&scalar, point)| {
             Self::msm_slice::<P>(scalar, &mut slices, window_bits);
-            bucket_msm.process_point_and_slices(&point, &slices);
+            bucket_msm.process_point_and_slices(point, &slices);
         });
 
         bucket_msm.process_complete();
-        return bucket_msm.batch_reduce();
+        bucket_msm.batch_reduce()
     }
 
     pub fn multi_scalar_mul_custom<P: Parameters>(
@@ -150,7 +150,7 @@ impl VariableBaseMSM {
         scalars: &[BigInt<P>],
     ) -> GroupProjective<P> {
         let opt_window_size = Self::get_opt_window_size(log2(points.len()));
-        Self::multi_scalar_mul_custom(&points, &scalars, opt_window_size, 2048, 256)
+        Self::multi_scalar_mul_custom(points, scalars, opt_window_size, 2048, 256)
     }
 }
 
@@ -165,14 +165,14 @@ mod collision_method_pippenger_tests {
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 1);
         // print!("slices {:?}\n", slices);
-        assert_eq!(slices.iter().eq([1, 0, 1].iter()), true);
+        assert!(slices.iter().eq([1, 0, 1].iter()));
     }
     #[test]
     fn test_msm_slice_window_size_2() {
         let scalar = G1BigInt::from(0b000110);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 2);
-        assert_eq!(slices.iter().eq([2, 1, 0].iter()), true);
+        assert!(slices.iter().eq([2, 1, 0].iter()));
     }
 
     #[test]
@@ -180,7 +180,7 @@ mod collision_method_pippenger_tests {
         let scalar = G1BigInt::from(0b010111000);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 3);
-        assert_eq!(slices.iter().eq([0, 0x80000001, 3].iter()), true);
+        assert!(slices.iter().eq([0, 0x80000001, 3].iter()));
     }
 
     #[test]
@@ -188,6 +188,6 @@ mod collision_method_pippenger_tests {
         let scalar = G1BigInt::from(0x123400007FFF);
         let mut slices: Vec<u32> = vec![0; 3];
         VariableBaseMSM::msm_slice::<Parameters>(scalar, &mut slices, 16);
-        assert_eq!(slices.iter().eq([0x7FFF, 0, 0x1234].iter()), true);
+        assert!(slices.iter().eq([0x7FFF, 0, 0x1234].iter()));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,8 +3,7 @@ use ark_ec::{models::ModelParameters, AffineCurve};
 use ark_ff::{FpParameters, PrimeField};
 
 pub const G1_SCALAR_SIZE: u32 =
-    <<<G1Affine as AffineCurve>::ScalarField as PrimeField>::Params as FpParameters>::MODULUS_BITS
-        as u32;
+    <<<G1Affine as AffineCurve>::ScalarField as PrimeField>::Params as FpParameters>::MODULUS_BITS;
 pub const G1_SCALAR_SIZE_GLV: u32 = 128u32;
 pub const GROUP_SIZE_IN_BITS: usize = 6;
 pub const GROUP_SIZE: usize = 1 << GROUP_SIZE_IN_BITS;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use ark_ec::{AffineCurve, ProjectiveCurve};
 use ark_ff::{PrimeField, UniformRand};
 
+#[allow(clippy::type_complexity)]
 pub fn generate_msm_inputs<A>(
     size: usize,
 ) -> (

--- a/tests/bitmap_tests.rs
+++ b/tests/bitmap_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 mod bitmap_tests {
+    use all_asserts::assert_false;
     use ark_msm::bitmap::Bitmap;
 
     fn setup() -> Bitmap {
@@ -9,24 +10,24 @@ mod bitmap_tests {
     #[test]
     fn test_set_when_only_once_return_false() {
         let mut bitmap = setup();
-        assert!(!bitmap.test_and_set(0));
-        assert!(!bitmap.test_and_set(33));
+        assert_false!(bitmap.test_and_set(0));
+        assert_false!(bitmap.test_and_set(33));
     }
 
     #[test]
     fn test_set_when_more_than_once_return_true() {
         let mut bitmap = setup();
-        assert!(!bitmap.test_and_set(0));
+        assert_false!(bitmap.test_and_set(0));
         assert!(bitmap.test_and_set(0));
     }
 
     #[test]
     fn test_clear() {
         let mut bitmap = setup();
-        assert!(!bitmap.test_and_set(0));
+        assert_false!(bitmap.test_and_set(0));
         assert!(bitmap.test_and_set(0));
 
         bitmap.clear();
-        assert!(!bitmap.test_and_set(0));
+        assert_false!(bitmap.test_and_set(0));
     }
 }

--- a/tests/bitmap_tests.rs
+++ b/tests/bitmap_tests.rs
@@ -3,30 +3,30 @@ mod bitmap_tests {
     use ark_msm::bitmap::Bitmap;
 
     fn setup() -> Bitmap {
-        return Bitmap::new(67);
+        Bitmap::new(67)
     }
 
     #[test]
     fn test_set_when_only_once_return_false() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(33), false);
+        assert!(!bitmap.test_and_set(0));
+        assert!(!bitmap.test_and_set(33));
     }
 
     #[test]
     fn test_set_when_more_than_once_return_true() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(0), true);
+        assert!(!bitmap.test_and_set(0));
+        assert!(bitmap.test_and_set(0));
     }
 
     #[test]
     fn test_clear() {
         let mut bitmap = setup();
-        assert_eq!(bitmap.test_and_set(0), false);
-        assert_eq!(bitmap.test_and_set(0), true);
+        assert!(!bitmap.test_and_set(0));
+        assert!(bitmap.test_and_set(0));
 
         bitmap.clear();
-        assert_eq!(bitmap.test_and_set(0), false);
+        assert!(!bitmap.test_and_set(0));
     }
 }

--- a/tests/glv_tests.rs
+++ b/tests/glv_tests.rs
@@ -62,7 +62,7 @@ mod glv_tests {
         ]));
         let p = G1Affine::from(<G1Affine as AffineCurve>::Projective::rand(&mut rng));
 
-        let mut endo_p = p.clone();
+        let mut endo_p = p;
         endomorphism(&mut endo_p);
 
         let lambda_p = G1Affine::from(p.mul(lambda));

--- a/tests/msm_tests.rs
+++ b/tests/msm_tests.rs
@@ -11,9 +11,9 @@ mod msm_test {
     use ark_std::UniformRand;
 
     fn verify_correctness(points: &[G1Affine], scalars: &[G1BigInt], window_size: u32) {
-        let baseline = BaselineVariableBaseMSM::multi_scalar_mul(&points, &scalars);
-        let opt =
-            VariableBaseMSM::multi_scalar_mul_custom(&points, &scalars, window_size, 2048, 256);
+        let baseline = BaselineVariableBaseMSM::multi_scalar_mul(points, scalars);
+        let opt = VariableBaseMSM::multi_scalar_mul_custom(points, scalars, window_size, 2048, 256);
+
         assert_eq!(baseline, opt);
     }
 


### PR DESCRIPTION
Waiting for #3 

- Used cargo-clippy-fix
- A few comments from clippy have been corrected manually
- Added the use of [`all_asserts`](https://docs.rs/all_asserts/latest/all_asserts/) crate, for better readability and to display more information, in case of an panic
- Added CI for formatting and linter checking