### PR TITLE
Minor improvements, in preparation for parallelization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-msm"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = [
     "Jiannan Ouyang <ouyang@snarkify.io>",
     "Boyu Sun <boyu@snarkify.io>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ num-bigint = {version = "0.4.0"}
 all_asserts = "2.3.1"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.5.1"
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.3.0-alpha.2"
 authors = [
     "Jiannan Ouyang <ouyang@snarkify.io>",
     "Boyu Sun <boyu@snarkify.io>",
-    "Chao Ma <chao@snarkify.io>"
+    "Chao Ma <chao@snarkify.io>",
+    "cyphersnake <mikhail@snarkify.io>",
 ]
 description = "An optimized multi-scalar muliplication (MSM) library based on arkworks"
 homepage = "https://github.com/snarkify/arkmsm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ rust-version = "1.63"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-ark-bls12-381 = {version = "0.3.0"}
-ark-ec = {version = "0.3.0"}
-ark-ff = {version = "0.3.0"}
-ark-std = {version = "0.3.0"}
-num-bigint = {version = "0.4.0"}
+ark-bls12-381 = "0.3.0"
+ark-ec = "0.3.0"
+ark-ff = "0.3.0"
+ark-std = "0.3.0"
+num-bigint = "0.4.0"
 all_asserts = "2.3.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ Detailed documentations about each optimization are available at [https://hackmd
 
 * Run Benchmarks:
     ```bash
-    cargo bench -- bench_with_baseline
-    cargo bench -- bench_window_size
+    cargo install cargo-critetion
+    cargo criterion --bench bench_with_baseline
+    cargo criterion --bench bench_window_size
     ```
 
 ## Acknowledgement

--- a/src/bucket_msm.rs
+++ b/src/bucket_msm.rs
@@ -67,8 +67,8 @@ impl<P: Parameters> BucketMSM<P> {
     pub fn process_point_and_slices_glv(
         &mut self,
         point: &GroupAffine<P>,
-        normal_slices: &Vec<u32>,
-        phi_slices: &Vec<u32>,
+        normal_slices: &[u32],
+        phi_slices: &[u32],
         is_neg_scalar: bool,
         is_neg_normal: bool,
     ) {
@@ -148,7 +148,7 @@ impl<P: Parameters> BucketMSM<P> {
         }
     }
 
-    pub fn process_point_and_slices(&mut self, point: &GroupAffine<P>, slices: &Vec<u32>) {
+    pub fn process_point_and_slices(&mut self, point: &GroupAffine<P>, slices: &[u32]) {
         assert!(
             self.num_windows as usize == slices.len(),
             "slices.len() {} should equal num_windows {}",
@@ -343,8 +343,8 @@ mod bucket_msm_tests {
         let p = G1Affine::from(p_prj);
         let q = G1Affine::from(q_prj);
 
-        bucket_msm.process_point_and_slices(&p, &vec![1u32, 3u32]);
-        bucket_msm.process_point_and_slices(&q, &vec![2u32, 3u32]);
+        bucket_msm.process_point_and_slices(&p, &[1u32, 3u32]);
+        bucket_msm.process_point_and_slices(&q, &[2u32, 3u32]);
         bucket_msm.process_complete();
         assert_eq!(bucket_msm.buckets[0], p);
         assert_eq!(bucket_msm.buckets[1], q);
@@ -363,9 +363,9 @@ mod bucket_msm_tests {
         let q = G1Affine::from(q_prj);
         let r = G1Affine::from(r_prj);
 
-        bucket_msm.process_point_and_slices(&p, &vec![1u32, 3u32, 4u32]);
-        bucket_msm.process_point_and_slices(&q, &vec![2u32, 3u32, 4u32]);
-        bucket_msm.process_point_and_slices(&r, &vec![2u32, 3u32, 5u32]);
+        bucket_msm.process_point_and_slices(&p, &[1u32, 3u32, 4u32]);
+        bucket_msm.process_point_and_slices(&q, &[2u32, 3u32, 4u32]);
+        bucket_msm.process_point_and_slices(&r, &[2u32, 3u32, 5u32]);
         bucket_msm.process_complete();
         assert_eq!(bucket_msm.buckets[0], p);
         assert_eq!(bucket_msm.buckets[1], q + r);
@@ -387,20 +387,8 @@ mod bucket_msm_tests {
         let mut p = G1Affine::from(p_prj);
         let mut q = G1Affine::from(q_prj);
 
-        bucket_msm.process_point_and_slices_glv(
-            &p,
-            &vec![1u32, 3u32],
-            &vec![4u32, 6u32],
-            false,
-            false,
-        );
-        bucket_msm.process_point_and_slices_glv(
-            &q,
-            &vec![2u32, 3u32],
-            &vec![5u32, 6u32],
-            false,
-            false,
-        );
+        bucket_msm.process_point_and_slices_glv(&p, &[1u32, 3u32], &[4u32, 6u32], false, false);
+        bucket_msm.process_point_and_slices_glv(&q, &[2u32, 3u32], &[5u32, 6u32], false, false);
         bucket_msm.process_complete();
         assert_eq!(bucket_msm.buckets[0], p);
         assert_eq!(bucket_msm.buckets[1], q);

--- a/src/bucket_msm.rs
+++ b/src/bucket_msm.rs
@@ -96,9 +96,9 @@ impl<P: Parameters> BucketMSM<P> {
         };
 
         self.cur_points.push(p);
-        for win in 0..normal_slices.len() {
-            if (normal_slices[win] as i32) > 0 {
-                let bucket_id = (win << self.bucket_bits) as u32 + normal_slices[win] - 1;
+        for (win, normal_slice) in normal_slices.iter().enumerate() {
+            if (*normal_slice as i32) > 0 {
+                let bucket_id = (win << self.bucket_bits) as u32 + normal_slice - 1;
                 self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
             }
         }
@@ -106,9 +106,9 @@ impl<P: Parameters> BucketMSM<P> {
         p.y = -p.y;
 
         self.cur_points.push(p);
-        for win in 0..normal_slices.len() {
-            if (normal_slices[win] as i32) < 0 {
-                let slice = normal_slices[win] & 0x7FFFFFFF;
+        for (win, normal_slice) in normal_slices.iter().enumerate() {
+            if (*normal_slice as i32) < 0 {
+                let slice = normal_slice & 0x7FFFFFFF;
                 if slice > 0 {
                     let bucket_id = (win << self.bucket_bits) as u32 + slice - 1;
                     self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
@@ -127,9 +127,9 @@ impl<P: Parameters> BucketMSM<P> {
         endomorphism(p_g1);
 
         self.cur_points.push(p);
-        for win in 0..phi_slices.len() {
-            if (phi_slices[win] as i32) > 0 {
-                let bucket_id = (win << self.bucket_bits) as u32 + phi_slices[win] - 1;
+        for (win, phi_slice) in phi_slices.iter().enumerate() {
+            if (*phi_slice as i32) > 0 {
+                let bucket_id = (win << self.bucket_bits) as u32 + phi_slice - 1;
                 self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
             }
         }
@@ -137,9 +137,9 @@ impl<P: Parameters> BucketMSM<P> {
         p.y = -p.y;
 
         self.cur_points.push(p);
-        for win in 0..phi_slices.len() {
-            if (phi_slices[win] as i32) < 0 {
-                let slice = phi_slices[win] & 0x7FFFFFFF;
+        for (win, phi_slice) in phi_slices.iter().enumerate() {
+            if (*phi_slice as i32) < 0 {
+                let slice = phi_slice & 0x7FFFFFFF;
                 if slice > 0 {
                     let bucket_id = (win << self.bucket_bits) as u32 + slice - 1;
                     self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
@@ -157,9 +157,9 @@ impl<P: Parameters> BucketMSM<P> {
         );
 
         self.cur_points.push(*point);
-        for win in 0..slices.len() {
-            if (slices[win] as i32) > 0 {
-                let bucket_id = (win << self.bucket_bits) as u32 + slices[win] - 1; // skip slice == 0
+        for (win, slice) in slices.iter().enumerate() {
+            if (*slice as i32) > 0 {
+                let bucket_id = (win << self.bucket_bits) as u32 + slice - 1; // skip slice == 0
                 self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
             }
         }
@@ -168,9 +168,9 @@ impl<P: Parameters> BucketMSM<P> {
         neg_p.y = -neg_p.y;
 
         self.cur_points.push(neg_p);
-        for win in 0..slices.len() {
-            if (slices[win] as i32) < 0 {
-                let slice = slices[win] & 0x7FFFFFFF;
+        for (win, slice) in slices.iter().enumerate() {
+            if (*slice as i32) < 0 {
+                let slice = slice & 0x7FFFFFFF;
                 if slice > 0 {
                     let bucket_id = (win << self.bucket_bits) as u32 + slice - 1; // skip slice == 0
                     self._process_slices(bucket_id, self.cur_points.len() as u32 - 1);
@@ -290,9 +290,9 @@ impl<P: Parameters> BucketMSM<P> {
 
     fn calc_running_sum_total(&mut self, running_sums: &[GroupAffine<P>]) -> GroupProjective<P> {
         let mut running_sum_total = GroupProjective::<P>::zero();
-        for i in 1..running_sums.len() {
+        for (i, running_sum) in running_sums.iter().enumerate().skip(1) {
             for _ in 0..i {
-                running_sum_total.add_assign_mixed(&running_sums[i]);
+                running_sum_total.add_assign_mixed(running_sum);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::needless_range_loop)]
-
 pub mod bitmap;
 pub mod glv;
 pub mod msm;

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -19,25 +19,14 @@ impl VariableBaseMSM {
     /// on a Ubuntu 20.04.2 LTS server with AMD EPYC 7282 16-Core CPU
     /// and 128G memory, the optimal performance may vary on a different
     /// configuration.
-    fn get_opt_window_size(k: u32) -> u32 {
-        if k < 10 {
-            return 8;
-        }
+    const fn get_opt_window_size(k: u32) -> u32 {
         match k {
-            10 => 10,
-            11 => 10,
-            12 => 10,
-            13 => 12,
-            14 => 12,
-            15 => 13,
-            16 => 13,
-            17 => 13,
-            18 => 13,
-            19 => 13,
-            20 => 15,
-            21 => 15,
-            22 => 15,
-            _ => 16,
+            0..=9 => 8,
+            10..=12 => 10,
+            13..=14 => 12,
+            15..=19 => 13,
+            20..=22 => 15,
+            23.. => 16,
         }
     }
 


### PR DESCRIPTION
# Why
In the course of working on parallelization, I made several improvements. See commit messages for details and explanations.

# Benchmark

```bash
msm/ArkMSM/8            time:   [5.3459 ms 5.3604 ms 5.3760 ms]
                        change: [-0.3594% +0.1632% +0.6680%] (p = 0.54 > 0.05)
                        No change in performance detected.
                        
msm/ArkMSM/9            time:   [8.6122 ms 8.6444 ms 8.6738 ms]
                        change: [-2.5043% -1.9604% -1.4498%] (p = 0.00 < 0.05)
                        Performance has improved.

msm/ArkMSM/10           time:   [14.284 ms 14.332 ms 14.379 ms]
                        change: [-0.1926% +0.3063% +0.8156%] (p = 0.23 > 0.05)
                        No change in performance detected.

msm/ArkMSM/11           time:   [24.370 ms 24.443 ms 24.519 ms]
                        change: [-2.2792% -1.7889% -1.2748%] (p = 0.00 < 0.05)
                        Performance has improved.

msm/ArkMSM/12           time:   [45.056 ms 45.325 ms 45.618 ms]
                        change: [-2.5791% -1.8751% -1.0970%] (p = 0.00 < 0.05)
                        Performance has improved.

msm/ArkMSM/13           time:   [83.591 ms 84.083 ms 84.593 ms]
                        change: [-2.3334% -1.5437% -0.7311%] (p = 0.00 < 0.05)
                        Change within noise threshold.

msm/ArkMSM/14           time:   [154.56 ms 155.26 ms 155.98 ms]
                        change: [-4.8370% -3.5226% -2.2166%] (p = 0.00 < 0.05)
                        Performance has improved.

msm/ArkMSM/15           time:   [285.72 ms 287.32 ms 288.98 ms]
                        change: [+0.8589% +1.5467% +2.2610%] (p = 0.00 < 0.05)
                        Change within noise threshold.

msm/ArkMSM/16           time:   [545.03 ms 548.49 ms 552.06 ms]
                        change: [-2.1217% -1.1221% -0.1317%] (p = 0.03 < 0.05)
                        Change within noise threshold.

msm/ArkMSM/17           time:   [1.0815 s 1.0897 s 1.0982 s]
                        change: [-0.5867% +0.5486% +1.6348%] (p = 0.33 > 0.05)
                        No change in performance detected.

msm/ArkMSM/18           time:   [2.1158 s 2.1282 s 2.1413 s]                             
                        change: [-0.9083% +0.0440% +1.0195%] (p = 0.93 > 0.05)
                        No change in performance detected.
```

Let me know if the improvement results are acceptable. 