### PR TITLE
Add unit tests for the general path when glv is not enabled

### DIFF
--- a/benches/bench_window_size.rs
+++ b/benches/bench_window_size.rs
@@ -22,6 +22,7 @@ fn bench_window_size(c: &mut Criterion) {
                         window_size,
                         2048,
                         256,
+                        true,
                     );
                 })
             });

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -133,12 +133,17 @@ impl VariableBaseMSM {
         window_bits: u32,
         max_batch: u32,
         max_collisions: u32,
+        glv_enabled: bool
     ) -> GroupProjective<P> {
         assert!(
             window_bits as usize > GROUP_SIZE_IN_BITS,
             "Window_bits must be greater than the default log(group size)"
         );
-        if TypeId::of::<P>() == TypeId::of::<G1Parameters>() {
+        if glv_enabled {
+            assert!(
+                TypeId::of::<P>() == TypeId::of::<G1Parameters>(),
+                "Glv is only supported for bls12-381 curve!"
+            );
             Self::multi_scalar_mul_g1_glv(points, scalars, window_bits, max_batch, max_collisions)
         } else {
             Self::multi_scalar_mul_general(points, scalars, window_bits, max_batch, max_collisions)
@@ -150,7 +155,7 @@ impl VariableBaseMSM {
         scalars: &[BigInt<P>],
     ) -> GroupProjective<P> {
         let opt_window_size = Self::get_opt_window_size(log2(points.len()));
-        Self::multi_scalar_mul_custom(points, scalars, opt_window_size, 2048, 256)
+        Self::multi_scalar_mul_custom(points, scalars, opt_window_size, 2048, 256, true)
     }
 }
 

--- a/src/msm.rs
+++ b/src/msm.rs
@@ -133,7 +133,7 @@ impl VariableBaseMSM {
         window_bits: u32,
         max_batch: u32,
         max_collisions: u32,
-        glv_enabled: bool
+        glv_enabled: bool,
     ) -> GroupProjective<P> {
         assert!(
             window_bits as usize > GROUP_SIZE_IN_BITS,

--- a/tests/msm_tests.rs
+++ b/tests/msm_tests.rs
@@ -7,7 +7,7 @@ use ark_msm::{msm::VariableBaseMSM, utils::generate_msm_inputs};
 #[cfg(test)]
 mod msm_test {
     use super::*;
-    use ark_msm::types::{G1_SCALAR_SIZE, G1BigInt};
+    use ark_msm::types::{G1BigInt, G1_SCALAR_SIZE};
     use ark_std::UniformRand;
 
     fn verify_correctness(points: &[G1Affine], scalars: &[G1BigInt], window_size: u32) {
@@ -15,10 +15,17 @@ mod msm_test {
             if !glv_enabled && G1_SCALAR_SIZE % window_size == 0 {
                 // G1_SCALAR_SIZE % window_size causes overflow when glv is not enabled
                 // TODO: remove this condition when this overflow issue is fixed
-                continue
+                continue;
             }
             let baseline = BaselineVariableBaseMSM::multi_scalar_mul(points, scalars);
-            let opt = VariableBaseMSM::multi_scalar_mul_custom(points, scalars, window_size, 2048, 256, glv_enabled);
+            let opt = VariableBaseMSM::multi_scalar_mul_custom(
+                points,
+                scalars,
+                window_size,
+                2048,
+                256,
+                glv_enabled,
+            );
 
             assert_eq!(baseline, opt);
         }


### PR DESCRIPTION
The current unit tests only cover the glv path, in this change we tweaked the algorithm selection logic a bit to allow testing non-glv path. 